### PR TITLE
Refactor tests for recordings sync from Redis when the recording is new

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'dotenv-rails', '~> 2.5.0'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'shoulda'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,12 @@ GEM
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
+    shoulda (3.6.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (~> 3.0)
+    shoulda-context (1.2.2)
+    shoulda-matchers (3.1.3)
+      activesupport (>= 4.0.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -175,6 +181,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   redis (~> 4.0)
   rubocop (~> 0.60.0)
+  shoulda
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
@@ -184,4 +191,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -54,6 +54,7 @@ class Recording < ApplicationRecord
 
       recording.sync_metadata_from_redis(payload['metadata']) if payload.key?('metadata')
       recording.sync_playbacks_from_redis(payload['playback']) if payload.key?('playback')
+      recording
     end
   end
 

--- a/test/models/recording_test.rb
+++ b/test/models/recording_test.rb
@@ -1,33 +1,191 @@
 require 'test_helper'
+require 'recordings_helper'
+
 
 class RecordingTest < ActiveSupport::TestCase
-  test '.sync_from_redis creates a recording on archive_started' do
-    event = {
-      header: {
-        timestamp: 5161997873,
-        name: 'archive_started',
-        current_time: 1542719593,
-        version: '0.0.1'
-      }, payload: {
-        record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-        meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
-      }
-    }.deep_stringify_keys
 
-    assert_difference 'Recording.count' do
-      Recording.sync_from_redis(event)
-    end
-    target = Recording.find_by(record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284')
-    assert_not_nil target
-    assert_nil target.meeting_id
-    assert_equal target.state, 'processing'
-    assert_nil target.starttime
-    assert_nil target.endtime
-    assert_nil target.name
-    assert_nil target.participants
-    assert_not target.published
+  setup do
+    @record_id = 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
   end
 
+  context '#sync_from_redis' do
+    setup do
+      @all_event_names = %w[
+        archive_started
+        archive_ended
+        sanity_started
+        sanity_ended
+        process_started
+        process_ended
+        publish_started
+        publish_ended
+      ]
+    end
+
+    context 'with any recording event' do
+      should 'create a recording if not existant' do
+        @all_event_names.each_with_index do |event_name, index|
+          event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+
+          assert_difference 'Recording.count' do
+            Recording.sync_from_redis(event)
+          end
+        end
+      end
+
+      should 'return the created recording' do
+        @all_event_names.each_with_index do |event_name, index|
+          event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+          recording = Recording.sync_from_redis(event)
+          assert_instance_of Recording, recording
+        end
+      end
+
+      should 'set the recording as published when "published" included in the payload' do
+        @all_event_names.each_with_index do |event_name, index|
+          event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+          event['payload']['published'] = 'true'
+          recording = Recording.sync_from_redis(event)
+          assert_equal true, recording.published
+        end
+      end
+
+      should 'sync metadata when metadata is included in the payload' do
+        @all_event_names.each_with_index do |event_name, index|
+          event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+          event['payload']['metadata'] = {}
+          mock = MiniTest::Mock.new
+          mock.expect(:call, nil, [String, Hash])
+          Metadatum.stub :upsert_by_record_id, mock do
+            Recording.sync_from_redis(event.deep_stringify_keys)
+          end
+          assert mock.verify
+        end
+      end
+
+      should 'save the recording name when meetingName included in metadata' do
+        @all_event_names.each_with_index do |event_name, index|
+          event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+          meeting_name = 'This is a meeting name'
+          event['payload']['metadata'] = { 'meetingName': meeting_name }
+          recording = Recording.sync_from_redis(event.deep_stringify_keys)
+          assert_equal meeting_name, recording.name
+        end
+      end
+
+    end
+
+    context 'with events from unpublished recording' do
+      setup do
+        # All events but 'publish_ended' are from unpublished recordings.
+        @unpublished_recording_event_names = @all_event_names - ['publish_ended']
+      end
+
+      should 'save the recording basic information' do
+        @unpublished_recording_event_names.each_with_index do |event_name, index|
+          event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+          recording = Recording.sync_from_redis(event)
+
+          assert_equal "Not Fred's Room", recording.meeting_id
+          assert_nil recording.name
+          assert_nil recording.starttime
+          assert_nil recording.endtime
+          assert_nil recording.participants
+        end
+      end
+
+      should 'not save the recording as published' do
+        @unpublished_recording_event_names.each_with_index do |event_name, index|
+          event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+          recording = Recording.sync_from_redis(event)
+
+          assert_not recording.published
+        end
+      end
+
+      context 'with events from a processing recording but not yet processed' do
+        setup do
+          @event_names = %w[
+            archive_started
+            archive_ended
+            sanity_started
+            sanity_ended
+            process_started
+          ]
+        end
+
+        should 'set the recording state as "processing"' do
+          @event_names.each_with_index do |event_name, index|
+            event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+            recording = Recording.sync_from_redis(event)
+            assert_equal 'processing', recording.state
+          end
+        end
+
+        should 'not set the recording as published' do
+          @event_names.each_with_index do |event_name, index|
+            event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+            recording = Recording.sync_from_redis(event)
+            assert_not recording.published
+          end
+        end
+      end
+
+      context 'with events from a processed recording but not yet published' do
+        setup do
+          @event_names = ['process_ended', 'publish_started']
+        end
+
+        should 'set the recording state as "processed"' do
+          @event_names.each_with_index do |event_name, index|
+            event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+            recording = Recording.sync_from_redis(event)
+            assert_equal 'processed', recording.state
+          end
+        end
+
+        should 'not set the recording as published' do
+          @event_names.each_with_index do |event_name, index|
+            event = redis_event(event_name, record_id: "#{@record_id}#{index}")
+            recording = Recording.sync_from_redis(event)
+            assert_not recording.published
+          end
+        end
+      end
+
+    end
+
+    context 'with events from published recording' do
+      setup do
+        # The only event from a published recording is 'publish_ended'
+        @event = redis_event('publish_ended')
+      end
+
+      should 'set the recording as published' do
+        recording = Recording.sync_from_redis(@event)
+        assert recording.published
+        assert 'published', recording.published
+      end
+
+      should 'save the start and the end time of the recording' do
+        expected_start_time = Time.at(Rational(@event['payload']['start_time'], 1000)).utc
+        expected_end_time = Time.at(Rational(@event['payload']['end_time'], 1000)).utc
+        recording = Recording.sync_from_redis(@event)
+        assert_equal expected_start_time, recording.starttime
+        assert_equal expected_end_time, recording.endtime
+      end
+
+      should 'save the recording number of participants' do
+        @event['payload']['participants'] = 4
+        recording = Recording.sync_from_redis(@event.deep_stringify_keys)
+        assert_equal 4, recording.participants
+      end
+    end
+  end
+
+  #
+  # Updates a recording because of an event
+  #
   test '.sync_from_redis updates an existent recording on archive_started' do
     r = recordings(:fred_room)
     event = {
@@ -53,36 +211,6 @@ class RecordingTest < ActiveSupport::TestCase
     assert_equal target.endtime, r.endtime
     assert_equal target.name, r.name
     assert_equal target.participants, r.participants
-    assert_not target.published
-  end
-
-  test '.sync_from_redis creates a recording on archive_ended' do
-    event = {
-      header: {
-        timestamp: 5161997873,
-        name: 'archive_ended',
-        current_time: 1542719593,
-        version: '0.0.1'
-      }, payload: {
-        success: true,
-        step_time: 1336,
-        external_meeting_id: "Not Fred's Room",
-        record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-        meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
-      }
-    }.deep_stringify_keys
-
-    assert_difference 'Recording.count' do
-      Recording.sync_from_redis(event)
-    end
-    target = Recording.find_by(record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284')
-    assert_not_nil target
-    assert_equal target.meeting_id, "Not Fred's Room"
-    assert_equal target.state, 'processing'
-    assert_nil target.starttime
-    assert_nil target.endtime
-    assert_nil target.name
-    assert_nil target.participants
     assert_not target.published
   end
 
@@ -117,34 +245,6 @@ class RecordingTest < ActiveSupport::TestCase
     assert_not target.published
   end
 
-  test '.sync_from_redis creates a recording on sanity_started' do
-    event = {
-      header: {
-        timestamp: 5161997873,
-        name: 'sanity_started',
-        current_time: 1542719593,
-        version: '0.0.1'
-      }, payload: {
-        external_meeting_id: "Not Fred's Room",
-        record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-        meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
-      }
-    }.deep_stringify_keys
-
-    assert_difference 'Recording.count' do
-      Recording.sync_from_redis(event)
-    end
-    target = Recording.find_by(record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284')
-    assert_not_nil target
-    assert_equal target.meeting_id, "Not Fred's Room"
-    assert_equal target.state, 'processing'
-    assert_nil target.starttime
-    assert_nil target.endtime
-    assert_nil target.name
-    assert_nil target.participants
-    assert_not target.published
-  end
-
   test '.sync_from_redis updates an existent recording on sanity_started' do
     r = recordings(:fred_room)
     event = {
@@ -171,36 +271,6 @@ class RecordingTest < ActiveSupport::TestCase
     assert_equal target.endtime, r.endtime
     assert_equal target.name, r.name
     assert_equal target.participants, r.participants
-    assert_not target.published
-  end
-
-  test '.sync_from_redis creates a recording on sanity_ended' do
-    event = {
-      header: {
-        timestamp: 5161997873,
-        name: 'sanity_ended',
-        current_time: 1542719593,
-        version: '0.0.1'
-      }, payload: {
-        success: true,
-        step_time: 557,
-        external_meeting_id: "Not Fred's Room",
-        record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-        meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
-      }
-    }.deep_stringify_keys
-
-    assert_difference 'Recording.count' do
-      Recording.sync_from_redis(event)
-    end
-    target = Recording.find_by(record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284')
-    assert_not_nil target
-    assert_equal target.meeting_id, "Not Fred's Room"
-    assert_equal target.state, 'processing'
-    assert_nil target.starttime
-    assert_nil target.endtime
-    assert_nil target.name
-    assert_nil target.participants
     assert_not target.published
   end
 
@@ -235,35 +305,6 @@ class RecordingTest < ActiveSupport::TestCase
     assert_not target.published
   end
 
-  test '.sync_from_redis creates a recording on process_started' do
-    event = {
-      header: {
-        timestamp: 5161997873,
-        name: 'process_started',
-        current_time: 1542719593,
-        version: '0.0.1'
-      }, payload: {
-        workflow: 'presentation',
-        external_meeting_id: "Not Fred's Room",
-        record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-        meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
-      }
-    }.deep_stringify_keys
-
-    assert_difference 'Recording.count' do
-      Recording.sync_from_redis(event)
-    end
-    target = Recording.find_by(record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284')
-    assert_not_nil target
-    assert_equal target.meeting_id, "Not Fred's Room"
-    assert_equal target.state, 'processing'
-    assert_nil target.starttime
-    assert_nil target.endtime
-    assert_nil target.name
-    assert_nil target.participants
-    assert_not target.published
-  end
-
   test '.sync_from_redis updates an existent recording on process_started' do
     r = recordings(:fred_room)
     event = {
@@ -291,37 +332,6 @@ class RecordingTest < ActiveSupport::TestCase
     assert_equal target.endtime, r.endtime
     assert_equal target.name, r.name
     assert_equal target.participants, r.participants
-    assert_not target.published
-  end
-
-  test '.sync_from_redis creates a recording on process_ended' do
-    event = {
-      header: {
-        timestamp: 5161997873,
-        name: 'process_ended',
-        current_time: 1542719593,
-        version: '0.0.1'
-      }, payload: {
-        workflow: 'presentation',
-        success: true,
-        step_time: 557,
-        external_meeting_id: "Not Fred's Room",
-        record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-        meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
-      }
-    }.deep_stringify_keys
-
-    assert_difference 'Recording.count' do
-      Recording.sync_from_redis(event)
-    end
-    target = Recording.find_by(record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284')
-    assert_not_nil target
-    assert_equal target.meeting_id, "Not Fred's Room"
-    assert_equal target.state, 'processed'
-    assert_nil target.starttime
-    assert_nil target.endtime
-    assert_nil target.name
-    assert_nil target.participants
     assert_not target.published
   end
 
@@ -354,35 +364,6 @@ class RecordingTest < ActiveSupport::TestCase
     assert_equal target.endtime, r.endtime
     assert_equal target.name, r.name
     assert_equal target.participants, r.participants
-    assert_not target.published
-  end
-
-  test '.sync_from_redis creates a recording on publish_started' do
-    event = {
-      header: {
-        timestamp: 5161997873,
-        name: 'publish_started',
-        current_time: 1542719593,
-        version: '0.0.1'
-      }, payload: {
-        workflow: 'presentation',
-        external_meeting_id: "Not Fred's Room",
-        record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-        meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
-      }
-    }.deep_stringify_keys
-
-    assert_difference 'Recording.count' do
-      Recording.sync_from_redis(event)
-    end
-    target = Recording.find_by(record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284')
-    assert_not_nil target
-    assert_equal target.meeting_id, "Not Fred's Room"
-    assert_equal target.state, 'processed'
-    assert_nil target.starttime
-    assert_nil target.endtime
-    assert_nil target.name
-    assert_nil target.participants
     assert_not target.published
   end
 
@@ -419,60 +400,7 @@ class RecordingTest < ActiveSupport::TestCase
   end
 
   test '.sync_from_redis creates a recording on publish_ended' do
-    event = {
-      header: {
-        timestamp: 5161997873,
-        name: 'publish_ended',
-        current_time: 1542719593,
-        version: '0.0.1'
-      }, payload: {
-        success: true,
-        step_time: 1793,
-        playback: [
-          {
-            format: 'presentation',
-            link: 'https://dev90.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-            processing_time: 5999,
-            duration: 29185,
-            extensions: {
-              preview: {
-                images: {
-                  image: [
-                    'https://dev90.bigbluebutton.org/presentation/a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1542719370905/thumbnails/thumb-1.png',
-                    'https://dev90.bigbluebutton.org/presentation/a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1542719370905/thumbnails/thumb-2.png'
-                  ]
-                }
-              }
-            },
-            size: 321302
-          }, {
-            format: 'podcast',
-            link: 'https://dev90.bigbluebutton.org/playback/podcast/2.0/playback.html?meetingId=a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-            processing_time: 9919,
-            duration: 22999,
-            extensions: {
-              preview: {
-                images: {
-                  image: 'https://dev90.bigbluebutton.org/podcast/a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284/podcast/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1542719370905/thumbnails/thumb-1.png'
-                }
-              }
-            },
-            size: 28892
-          }
-        ], metadata: {
-          meetingName: "Certainly not Fred's Room",
-          isBreakout: 'false',
-          meetingId: "Not Fred's Room"
-        },
-        raw_size: 8166022,
-        start_time: 1542719370284,
-        end_time: 1542719443220,
-        workflow: 'presentation',
-        external_meeting_id: "Not Fred's Room",
-        record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
-        meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
-      }
-    }.deep_stringify_keys
+    event = redis_publish_ended_event
 
     assert_difference 'Recording.count' do
       assert_difference 'Metadatum.count', 3 do
@@ -519,7 +447,7 @@ class RecordingTest < ActiveSupport::TestCase
     thumbnail_url = '/presentation/a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'\
                     '/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1542719370905'\
                     '/thumbnails/thumb-2.png'
-    assert_not_nil pf.thumbnails.find_by(url:thumbnail_url )
+    assert_not_nil pf.thumbnails.find_by(url: thumbnail_url)
 
     pf = target.playback_formats.find_by(format: 'podcast')
     assert_not_nil pf

--- a/test/recordings_helper.rb
+++ b/test/recordings_helper.rb
@@ -1,0 +1,95 @@
+#
+# Creates a Redis event by the given name.
+#
+# If finished is `true`, sets the attributes `success` and `step_time` in the payload.
+#
+# @param [String] name Event name
+# @param [Boolean] finished Indicates if the event finished or not
+# @param [String] workflow Workflow name
+# @param [String] record_id Record identifier
+#
+# @return [Hash] Redis event
+#
+def redis_event(name, finished: false, workflow: nil, record_id: nil)
+  return redis_publish_ended_event if name == 'publish_ended'
+  event = {
+    header: {
+      timestamp: 5161997873,
+      name: name,
+      current_time: 1542719593,
+      version: '0.0.1'
+    },
+    payload:
+    {
+      external_meeting_id: "Not Fred's Room",
+      record_id: record_id,
+      meeting_id: record_id
+    }
+  }
+
+  if finished
+    event[:payload][:success] = true
+    event[:payload][:step_time] = 1336
+  end
+
+  event[:payload][:workflow] = workflow if workflow
+
+  event.deep_stringify_keys
+end
+
+def redis_publish_ended_event
+  {
+    header: {
+      timestamp: 5161997873,
+      name: 'publish_ended',
+      current_time: 1542719593,
+      version: '0.0.1'
+    }, payload: {
+      success: true,
+      step_time: 1793,
+      playback: [
+        {
+          format: 'presentation',
+          link: 'https://dev90.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
+          processing_time: 5999,
+          duration: 29185,
+          extensions: {
+            preview: {
+              images: {
+                image: [
+                  'https://dev90.bigbluebutton.org/presentation/a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1542719370905/thumbnails/thumb-1.png',
+                  'https://dev90.bigbluebutton.org/presentation/a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1542719370905/thumbnails/thumb-2.png'
+                ]
+              }
+            }
+          },
+          size: 321302
+        }, {
+          format: 'podcast',
+          link: 'https://dev90.bigbluebutton.org/playback/podcast/2.0/playback.html?meetingId=a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
+          processing_time: 9919,
+          duration: 22999,
+          extensions: {
+            preview: {
+              images: {
+                image: 'https://dev90.bigbluebutton.org/podcast/a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284/podcast/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1542719370905/thumbnails/thumb-1.png'
+              }
+            }
+          },
+          size: 28892
+        }
+      ], metadata: {
+        meetingName: "Certainly not Fred's Room",
+        isBreakout: 'false',
+        meetingId: "Not Fred's Room"
+      },
+      raw_size: 8166022,
+      start_time: 1542719370284,
+      end_time: 1542719443220,
+      workflow: 'presentation',
+      external_meeting_id: "Not Fred's Room",
+      record_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284',
+      meeting_id: 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
+    }
+  }.deep_stringify_keys
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require 'minitest/mock'
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
- Refactored the tests to describe the behavior of `sync_with_redis` when the event is from a new recording. 

- As the hash for redis events is long, a helper to build a redis event was added. The hash for the event `publish_ended` is handled apart as it has more elements.

- Added `shoulda` gem to use `context` and `should` in tests.