### PR TITLE
Pass all tests and Travis check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
     - db/schema.rb
 Metrics/AbcSize:
   Max: 30
+  Exclude:
+  - app/controllers/recordings_controller.rb
 Metrics/BlockLength:
   Exclude:
     - "**/*.builder"
@@ -47,3 +49,8 @@ Metrics/ClassLength:
   - app/models/recording.rb
   - test/models/recording_test.rb
   - test/controllers/bigbluebutton_api_controller_test.rb
+Metrics/PerceivedComplexity:
+  Exclude:
+  - app/controllers/recordings_controller.rb
+
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ Naming/AccessorMethodName:
   Exclude:
   - app/controllers/recordings_controller.rb
   - app/controllers/data_controller.rb
+Lint/ScriptPermission:
+  Exclude:
+  - scripts/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ inherit_mode:
 AllCops:
   Exclude:
     - db/schema.rb
+Lint/ScriptPermission:
+  Exclude:
+  - scripts/*.rb
 Metrics/AbcSize:
   Max: 30
   Exclude:
@@ -13,15 +16,25 @@ Metrics/BlockLength:
     - "**/*.builder"
     - test/models/recording_test.rb
     - test/controllers/bigbluebutton_api_controller_test.rb
+Metrics/ClassLength:
+  Exclude:
+  - app/models/recording.rb
+  - test/models/recording_test.rb
+  - test/controllers/bigbluebutton_api_controller_test.rb
 Metrics/CyclomaticComplexity:
   Max: 12
 Metrics/LineLength:
   Max: 132
 Metrics/MethodLength:
   Max: 20
+Metrics/PerceivedComplexity:
+  Exclude:
+  - app/controllers/recordings_controller.rb
 Naming/AccessorMethodName:
   Exclude:
     - app/controllers/bigbluebutton_api_controller.rb
+    - app/controllers/recordings_controller.rb
+    - app/controllers/data_controller.rb
 Naming/MethodName:
   Exclude:
     - app/controllers/bigbluebutton_api_controller.rb
@@ -37,20 +50,3 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/NumericLiterals:
   Enabled: false
-Naming/AccessorMethodName:
-  Exclude:
-  - app/controllers/recordings_controller.rb
-  - app/controllers/data_controller.rb
-Lint/ScriptPermission:
-  Exclude:
-  - scripts/*.rb
-Metrics/ClassLength:
-  Exclude:
-  - app/models/recording.rb
-  - test/models/recording_test.rb
-  - test/controllers/bigbluebutton_api_controller_test.rb
-Metrics/PerceivedComplexity:
-  Exclude:
-  - app/controllers/recordings_controller.rb
-
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,8 @@ Naming/AccessorMethodName:
 Lint/ScriptPermission:
   Exclude:
   - scripts/*.rb
+Metrics/ClassLength:
+  Exclude:
+  - app/models/recording.rb
+  - test/models/recording_test.rb
+  - test/controllers/bigbluebutton_api_controller_test.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,8 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - "**/*.builder"
+    - test/models/recording_test.rb
+    - test/controllers/bigbluebutton_api_controller_test.rb
 Metrics/CyclomaticComplexity:
   Max: 12
 Metrics/LineLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,19 @@
 language: ruby
 rvm:
   - 2.5
-dist: cosmic
+before_install:
+  - sqlite3 --version
+  - cd ~
+  - wget https://www.sqlite.org/2019/sqlite-autoconf-3280000.tar.gz
+  - tar zxvf sqlite-autoconf-3280000.tar.gz
+  - cd sqlite-autoconf-3280000
+  - ./configure --prefix=$HOME/opt/sqlite
+  - make
+  - make install
+  - export PATH=$HOME/opt/sqlite/bin:$PATH
+  - export LD_LIBRARY_PATH=$HOME/opt/sqlite/lib
+  - export LD_RUN_PATH=$HOME/opt/sqlite/lib
+  - source ~/.bash_profile
+  - sqlite3 --version
+  - cd $TRAVIS_BUILD_DIR
+dist: bionic

--- a/Gemfile
+++ b/Gemfile
@@ -47,4 +47,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
-gem 'bbbevents', path: '/usr/src/bbb-events'
+gem 'bbbevents', github: 'bigbluebutton/bbb-events'

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'annotate'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'rubocop', '~> 0.60.0', require: false
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,9 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    annotate (3.0.3)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     arel (9.0.0)
     ast (2.4.0)
     bootsnap (1.3.2)
@@ -172,6 +175,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   bbbevents!
   bootsnap (>= 1.1.0)
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
-PATH
-  remote: /usr/src/bbb-events
+GIT
+  remote: https://github.com/bigbluebutton/bbb-events.git
+  revision: 8d879171146b6c4d2f333a63c25bc4b89ea7c234
   specs:
-    bbbevents (1.0.0)
-      activesupport
+    bbbevents (1.2.0)
+      activesupport (>= 5.0.0.1, < 6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/models/datum.rb
+++ b/app/models/datum.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: data
+#
+#  id        :integer          not null, primary key
+#  record_id :string
+#  raw_data  :json
+#
+
 class Datum < ApplicationRecord
   # we do this through :record_id so we can parse data independently from recordings
   # data might have a recording or might not

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: metadata
+#
+#  id           :integer          not null, primary key
+#  recording_id :integer
+#  key          :string
+#  value        :string
+#
+
 class Metadatum < ApplicationRecord
   belongs_to :recording
 

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -20,7 +20,10 @@ class Metadatum < ApplicationRecord
     record_ids.each do |record_id|
       insert_records << [record_id_col, record_id]
     end
+    insert_metadatum(metadata, record_ids, insert_records)
+  end
 
+  def self.insert_metadatum(metadata, record_ids, insert_records)
     Metadatum.connection.insert(
       'INSERT INTO "metadata" ("recording_id", "key", "value") '\
         'WITH "new_metadata" AS '\

--- a/app/models/playback_format.rb
+++ b/app/models/playback_format.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: playback_formats
+#
+#  id              :integer          not null, primary key
+#  recording_id    :integer
+#  format          :string
+#  url             :string
+#  length          :integer
+#  processing_time :integer
+#
+
 class PlaybackFormat < ApplicationRecord
   belongs_to :recording
   has_many :thumbnails, dependent: :destroy

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: recordings
+#
+#  id           :integer          not null, primary key
+#  record_id    :string
+#  meeting_id   :string
+#  name         :string
+#  published    :boolean
+#  participants :integer
+#  state        :string
+#  starttime    :datetime
+#  endtime      :datetime
+#  deleted_at   :datetime
+#
+
 require 'redis_publisher'
 
 class Recording < ApplicationRecord

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: thumbnails
+#
+#  id                 :integer          not null, primary key
+#  playback_format_id :integer
+#  width              :integer
+#  height             :integer
+#  alt                :string
+#  url                :string
+#  sequence           :integer
+#
+
 class Thumbnail < ApplicationRecord
   belongs_to :playback_format
   default_scope { order(sequence: :asc) }

--- a/test/controllers/bigbluebutton_api_controller_test.rb
+++ b/test/controllers/bigbluebutton_api_controller_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 require 'redis_publisher'
 
 class BigbluebuttonApiControllerTest < ActionDispatch::IntegrationTest
-
   def run
     # Stub the Redis publisher calls, each test case expects maximun 2 calls.
     mock = MiniTest::Mock.new

--- a/test/controllers/bigbluebutton_api_controller_test.rb
+++ b/test/controllers/bigbluebutton_api_controller_test.rb
@@ -1,6 +1,17 @@
 require 'test_helper'
+require 'redis_publisher'
 
 class BigbluebuttonApiControllerTest < ActionDispatch::IntegrationTest
+
+  def run
+    # Stub the Redis publisher calls, each test case expects maximun 2 calls.
+    mock = MiniTest::Mock.new
+    2.times.each { mock.expect :publish, true, [String, String] }
+    ::RedisPublisher.stub :redis, mock do
+      super
+    end
+  end
+
   # getRecordings
   test 'getRecordings with no parameters returns checksum error' do
     get bigbluebutton_api_get_recordings_url

--- a/test/models/recording_test.rb
+++ b/test/models/recording_test.rb
@@ -1,11 +1,21 @@
 require 'test_helper'
 require 'recordings_helper'
-
+require 'redis_publisher'
 
 class RecordingTest < ActiveSupport::TestCase
 
   setup do
     @record_id = 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
+  end
+
+  def run
+    # Stub the Redis publisher calls, each tests case expects maximun 8 calls
+    # which is the number of events we have. See @all_event_names
+    mock = MiniTest::Mock.new
+    8.times.each { mock.expect :publish, true, [String, String] }
+    ::RedisPublisher.stub :redis, mock do
+      super
+    end
   end
 
   context '#sync_from_redis' do

--- a/test/models/recording_test.rb
+++ b/test/models/recording_test.rb
@@ -3,7 +3,6 @@ require 'recordings_helper'
 require 'redis_publisher'
 
 class RecordingTest < ActiveSupport::TestCase
-
   setup do
     @record_id = 'a0fcb226a234fccc45a9417f8d7c871792e25e1d-1542719370284'
   end
@@ -82,7 +81,6 @@ class RecordingTest < ActiveSupport::TestCase
           assert_equal meeting_name, recording.name
         end
       end
-
     end
 
     context 'with events from unpublished recording' do
@@ -143,7 +141,7 @@ class RecordingTest < ActiveSupport::TestCase
 
       context 'with events from a processed recording but not yet published' do
         setup do
-          @event_names = ['process_ended', 'publish_started']
+          @event_names = %w[process_ended publish_started]
         end
 
         should 'set the recording state as "processed"' do
@@ -162,7 +160,6 @@ class RecordingTest < ActiveSupport::TestCase
           end
         end
       end
-
     end
 
     context 'with events from published recording' do

--- a/test/recordings_helper.rb
+++ b/test/recordings_helper.rb
@@ -12,7 +12,18 @@
 #
 def redis_event(name, finished: false, workflow: nil, record_id: nil)
   return redis_publish_ended_event if name == 'publish_ended'
-  event = {
+
+  event = redis_event_base(name, record_id)
+  if finished
+    event[:payload][:success] = true
+    event[:payload][:step_time] = 1336
+  end
+  event[:payload][:workflow] = workflow if workflow
+  event.deep_stringify_keys
+end
+
+def redis_event_base(name, record_id)
+  {
     header: {
       timestamp: 5161997873,
       name: name,

--- a/test/recordings_helper.rb
+++ b/test/recordings_helper.rb
@@ -37,17 +37,9 @@ def redis_event_base(name, record_id)
       meeting_id: record_id
     }
   }
-
-  if finished
-    event[:payload][:success] = true
-    event[:payload][:step_time] = 1336
-  end
-
-  event[:payload][:workflow] = workflow if workflow
-
-  event.deep_stringify_keys
 end
 
+# rubocop:disable Metrics/MethodLength
 def redis_publish_ended_event
   {
     header: {
@@ -104,3 +96,4 @@ def redis_publish_ended_event
     }
   }.deep_stringify_keys
 end
+# rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
- Stub Redis so it is not necessary for tests.
- Fix more cops, many files were excluded from the rules for now. We still have to fix them.
- The gem bbb-events now is installed from github, this makes the repo independent of a BBB server which expects to find the gem at /usr/src.
- Added the gem 'annotate' to see fields and their types listed in each model file.
- Upgrade to sqlite 3.28 in bionic to get tests passing in Travis. (version 3.24 is needed and comes in cosmic but that dist is not supported by Travis)