### PR TITLE
Add an API call to authorize the playback of recordings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,4 +47,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'bbbevents', path: '/usr/src/bbb-events'
+gem 'bbbevents', github: 'bigbluebutton/bbb-events'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
-PATH
-  remote: /usr/src/bbb-events
+GIT
+  remote: https://github.com/bigbluebutton/bbb-events.git
+  revision: 8d879171146b6c4d2f333a63c25bc4b89ea7c234
   specs:
-    bbbevents (1.0.0)
-      activesupport
+    bbbevents (1.2.0)
+      activesupport (>= 5.0.0.1, < 6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/recordings_controller.rb
+++ b/app/controllers/recordings_controller.rb
@@ -1,6 +1,8 @@
 class RecordingsController < ApplicationController
   before_action :parse_metadata
 
+  skip_before_action :checksum, only: :authorizeRecording
+
   def getRecordings
     query = Recording.includes(playback_formats: [:thumbnails], metadata: [])
     if params[:recordID].present?
@@ -87,5 +89,14 @@ class RecordingsController < ApplicationController
 
     @deleted = destroyed_recs.count.positive?
     render :delete_recordings
+  end
+
+  def authorizeRecording
+    rec = Recording.find_by(record_id: params[:meetingId])
+    if rec.present? && rec.published
+      head(200)
+    else
+      head(403)
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,10 @@ Rails.application.routes.draw do
       to: 'recordings#deleteRecordings',
       as: 'recordings_delete_recordings',
       defaults: { format: 'xml' }
+  get "#{base}/authorizeRecording",
+      to: 'recordings#authorizeRecording',
+      as: 'recordings_authorize_recording',
+      defaults: { format: 'xml' }
 
   get "#{base}/getData",
       to: 'data#getData',


### PR DESCRIPTION
Adds the API call `authorizeRecording` to be called by nginx when serving the playback files of recordings. It returns a 403 if the recording cannot be played (not found or unpublished) and 200 if it can.

To be used, these new blocks have to be added to the nginx config in BigBlueButton (`/etc/bigbluebutton/nginx/presentation.nginx`):

```
location /bigbluebutton/api/authorizeRecording {
    internal;
    set $query '';
    if ($request_uri ~* "[^\?]+\?(.*)$") {
        set $query $1;
    }
    proxy_pass               http://10.0.51.154:3000/bigbluebutton/api/authorizeRecording?$query;
    proxy_pass_request_body  off;
    proxy_set_header         Content-Length "";
    proxy_set_header         X-Original-URI $request_uri;
}

location ~* /playback/presentation/.*/playback.html$ {
    auth_request /bigbluebutton/api/authorizeRecording;
    auth_request_set $auth_status $upstream_status;
    root    /var/bigbluebutton;
    index  index.html index.htm;
}
